### PR TITLE
Update Docker Tag missaelcorm/schedulesync-web:f9de4b8

### DIFF
--- a/environments/dev/terraform.tfvars
+++ b/environments/dev/terraform.tfvars
@@ -9,7 +9,7 @@ availability_zones = ["us-west-2a", "us-west-2b"]
 
 frontend_image = {
   repository_url = "missaelcorm/schedulesync-web"
-  tag            = "v0.11"
+  tag            = "f9de4b8"
 }
 
 backend_image = {


### PR DESCRIPTION
# Update Docker Tag
## Description
Update Docker Tag `f9de4b8` for `frontend` service:
- Docker Image: `missaelcorm/schedulesync-web`
- Docker Tag: `f9de4b8`
- Environment: `dev`
- SHA: `f9de4b831f819c595114f71759f7ac95e97babbe`