### PR TITLE
Update Docker Tag missaelcorm/schedulesync-api:680a9e7

### DIFF
--- a/environments/dev/terraform.tfvars
+++ b/environments/dev/terraform.tfvars
@@ -14,5 +14,5 @@ frontend_image = {
 
 backend_image = {
   repository_url = "missaelcorm/schedulesync-api"
-  tag            = "v0.18"
+  tag            = "680a9e7"
 }


### PR DESCRIPTION
# Update Docker Tag
## Description
Update Docker Tag `680a9e7` for `backend` service:
- Docker Image: `missaelcorm/schedulesync-api`
- Docker Tag: `680a9e7`
- Environment: `dev`
- SHA: `680a9e7a91bed062e0613cb28acf4026dbb3343c`