### PR TITLE
Update Docker Tag missaelcorm/schedulesync-api:aae21e2

### DIFF
--- a/environments/dev/terraform.tfvars
+++ b/environments/dev/terraform.tfvars
@@ -14,5 +14,5 @@ frontend_image = {
 
 backend_image = {
   repository_url = "missaelcorm/schedulesync-api"
-  tag            = "680a9e7"
+  tag            = "aae21e2"
 }


### PR DESCRIPTION
# Update Docker Tag
## Description
Update Docker Tag `aae21e2` for `backend` service:
- Docker Image: `missaelcorm/schedulesync-api`
- Docker Tag: `aae21e2`
- Environment: `dev`
- SHA: `aae21e260d36c2dbe4f99dd01fadb05e72ea45f0`