### PR TITLE
Update Docker Tag missaelcorm/schedulesync-web:aae21e2

### DIFF
--- a/environments/dev/terraform.tfvars
+++ b/environments/dev/terraform.tfvars
@@ -9,7 +9,7 @@ availability_zones = ["us-west-2a", "us-west-2b"]
 
 frontend_image = {
   repository_url = "missaelcorm/schedulesync-web"
-  tag            = "v0.11"
+  tag            = "aae21e2"
 }
 
 backend_image = {


### PR DESCRIPTION
# Update Docker Tag
## Description
Update Docker Tag `aae21e2` for `frontend` service:
- Docker Image: `missaelcorm/schedulesync-web`
- Docker Tag: `aae21e2`
- Environment: `dev`
- SHA: `aae21e260d36c2dbe4f99dd01fadb05e72ea45f0`