### PR TITLE
Update Docker Tag missaelcorm/schedulesync-api:b929b2d

### DIFF
--- a/environments/dev/terraform.tfvars
+++ b/environments/dev/terraform.tfvars
@@ -14,5 +14,5 @@ frontend_image = {
 
 backend_image = {
   repository_url = "missaelcorm/schedulesync-api"
-  tag            = "f5eb067"
+  tag            = "b929b2d"
 }


### PR DESCRIPTION
# Update Docker Tag
## Description
Update Docker Tag `b929b2d` for `backend` service:
- Docker Image: `missaelcorm/schedulesync-api`
- Docker Tag: `b929b2d`
- Environment: `dev`
- SHA: `b929b2d69cc1d6e001c4a6e9a08657001894a531`